### PR TITLE
Fix pathing in examples

### DIFF
--- a/examples/alpmenu.rb
+++ b/examples/alpmenu.rb
@@ -1,6 +1,10 @@
 require 'canis/core/util/app'
 
-  App.new do 
+  def load_relative(path)
+    load File.expand_path("../#{path}", __FILE__)
+  end
+
+  App.new do
     #title "Demo of Menu - canis"
     #subtitle "Hit F1 to quit, F2 for menubar toggle"
     header = app_header "canis #{Canis::VERSION}", :text_center => "Alpine Menu Demo", :text_right =>""
@@ -10,24 +14,24 @@ require 'canis/core/util/app'
       w = 60
       menulink :text => "&View Dirs", :width => w, :description => "View Dirs in tree"  do |s, *stuff|
         message "Pressed #{s.text} "
-        load './dirtree.rb'
+        load_relative './dirtree.rb'
         #require './viewtodo'; todo = ViewTodo::TodoApp.new; todo.run
       end
       blank
       menulink :text => "&Tabular", :width => w, :description => "Tabula Rasa"  do |s, *stuff|
         message "Pressed #{s.text} "
-        load './tabular.rb'
+        load_relative './tabular.rb'
         #require './testtodo'; todo = TestTodo::TodoApp.new; todo.run
       end
       blank
       menulink :text => "&Messages", :width => w, :description => "View Tasks"  do |s, *stuff|
         message "Pressed #{s.text} "
-        load './tasks.rb'
+        load_relative './tasks.rb'
       end
       blank
       menulink :text => "&Database", :width => w, :description => "Database Demo"  do |s, *stuff|
         message "Pressed #{s.getvalue} "
-        load './dbdemo.rb'
+        load_relative './dbdemo.rb'
       end
       blank
       # somehow ? in mnemonic won't work

--- a/examples/app.sample
+++ b/examples/app.sample
@@ -6,11 +6,11 @@ here as you want
 eos
 end
 
-App.new do 
+App.new do
     ## application code comes here
     @form.help_manager.help_text = help_text()
 
-    @header = app_header "My App #{MyApp::VERSION}", :text_center => "Yet Another Email Client that sucks", :text_right =>"Some text", :color => :black, :bgcolor => :white
+    @header = app_header "My App #{App::VERSION}", :text_center => "Yet Another Email Client that sucks", :text_right =>"Some text", :color => :black, :bgcolor => :white
 
     @status_line = status_line
     @status_line.command {

--- a/examples/appemail.rb
+++ b/examples/appemail.rb
@@ -8,11 +8,11 @@ require './common/rmail'
 # this will go into top namespace so will conflict with other apps!
 def testchoose
   # list filters as you type
-  $log.debug "called CHOOSE " if $log.debug? 
+  $log.debug "called CHOOSE " if $log.debug?
   filter = "*"
   filter = ENV['PWD']+"/*"
   str = choose filter, :title => "Files", :prompt => "Choose a file: "
-  message "We got #{str} " 
+  message "We got #{str} "
 end
 def testnumberedmenu
   list1 =  %w{ ruby perl python erlang rake java lisp scheme chicken }
@@ -33,7 +33,7 @@ def testdisplay_text
 end
 def testdir
   # this behaves like vim's file selector, it fills in values
-  str = ask("File?  ", Pathname)  do |q| 
+  str = ask("File?  ", Pathname)  do |q|
     q.completion_proc = Proc.new {|str| Dir.glob(str +"*").collect { |f| File.directory?(f) ? f+"/" : f  } }
     q.helptext = "Enter start of filename and tab to get completion"
   end
@@ -42,16 +42,16 @@ end
 def test
 end
 def saveas1
-  @tv.saveas 
+  @tv.saveas
 end
 
-# experimental. 
+# experimental.
 # if components have some commands, can we find a way of passing the command to them
 # method_missing gave a stack overflow.
 def execute_this(meth, *args)
-  $log.debug "app email got #{meth}  " if $log.debug? 
+  $log.debug "app email got #{meth}  " if $log.debug?
   cc = @vim.current_component
-  [cc, @lb2, @tv].each do |c|  
+  [cc, @lb2, @tv].each do |c|
     if c.respond_to?(meth, true)
       c.send(meth, *args)
       return true
@@ -60,7 +60,7 @@ def execute_this(meth, *args)
   false
 end
 
-App.new do 
+App.new do
   ht = 24
   @messages = nil
   $unread_hash = {}
@@ -72,7 +72,7 @@ App.new do
 
   stack :margin_top => 1, :margin => 0, :width => :EXPAND do
     # NOTE: please fix the next 2 lines based on where your mbox files reside
-    model = ["~/mbox"] 
+    model = ["~/mbox"]
     others = "~/mail/"
     boxes = Dir.new(File.expand_path(others)).entries
     boxes.delete(".")
@@ -84,28 +84,28 @@ App.new do
     @vim = master_detail :width => :EXPAND
     @dirs = listbox :list => model, :height => ht, :border_attrib => borderattrib, :suppress_borders => true
     @dirs.one_key_selection = false
-    
+
     # commands that can be mapped to or executed using M-x
     # however, commands of components aren't yet accessible.
     def get_commands
       %w{ testchoose testnumberedmenu testdisplay_list testdisplay_text testdir saveas1 }
     end
-    # we override/open instance so as to only print basename. Also, print unread count 
+    # we override/open instance so as to only print basename. Also, print unread count
     def @dirs.convert_value_to_text(text, crow)
       str = File.basename(text)
       if $unread_hash.has_key?(str)
         str << " (#{$unread_hash[str]})"
       else
-        str 
+        str
       end
     end
     def test1XX
-      $log.debug "called test1 " if $log.debug? 
+      $log.debug "called test1 " if $log.debug?
       str = choose "*.rb", :title => "Files", :prompt => "Choose a file: "
     end
     def help_text
       <<-eos
-               APPEMAIL HELP 
+               APPEMAIL HELP
 
       This is some help text for appemail.
       We are testing out this feature.
@@ -131,7 +131,7 @@ App.new do
     end
     @vim.set_left_component @dirs
 
-    
+
     @mails = []
     headings = %w{ Stat #  Date From Subject }
     @lb2 = tabular_widget :suppress_borders => true

--- a/examples/atree.rb
+++ b/examples/atree.rb
@@ -1,11 +1,11 @@
 require 'canis/core/util/app'
 
-App.new do 
+App.new do
   var = Variable.new
-  header = app_header "canis #{Canis::VERSION}", :text_center => "Tree Demo", :text_right =>"New Improved!", :color => :black, :bgcolor => :white, :attr => :bold 
+  header = app_header "canis #{Canis::VERSION}", :text_center => "Tree Demo", :text_right =>"New Improved!", :color => :black, :bgcolor => :white, :attr => :bold
   message "Press Enter to expand/collapse"
 
-      @form.bind_key(FFI::NCurses::KEY_F3) { 
+      @form.bind_key(FFI::NCurses::KEY_F3) {
         require 'canis/core/util/viewer'
         Canis::Viewer.view("canis14.log", :close_key => KEY_ENTER, :title => "<Enter> to close")
       }
@@ -37,7 +37,7 @@ App.new do
         stack :margin_top => 0, :width_pc => "30" do
 
           # using an Array, these would be expanded on selection, using an event
-          tree :data => Dir.glob("*"), :title=> "[ Array ]" do 
+          tree :data => Dir.glob("*"), :title=> "[ Array ]" do
             command do |node|
               # insert dir entries unless done so already
               if node.children && !node.children.empty?
@@ -71,7 +71,7 @@ App.new do
           leaf1 << "leaf12"
 
           # more rubyish way
-          root.add "blocky", true do 
+          root.add "blocky", true do
             add "block2"
             add "block3" do
               add "block31"
@@ -86,14 +86,14 @@ App.new do
           # using height_pc as 100 was causing prefresh to fail if file lines went beyond 31
           # tput lines gives 32 so only when file length exceeded was it actually writing beyond screen
           t = textview  :suppress_borders => true, :height_pc => 90, :color => :green, :bgcolor => :black
-            var.command do |filename| 
+            var.command do |filename|
               filename = filename.value
               if File.directory? filename
                 lines = Dir.entries(filename )
                 t.set_content lines
               elsif File.exist? filename
                 # next line bombs on "invalid byte sequence on UTF-8" on split.
-                lines = File.open(filename,'r').read.split("\n") 
+                lines = File.open(filename,'r').read.split("\n")
                 # next line bombs on binary files. normally we would check file type using +file+ command
                 t.set_content lines
               else

--- a/examples/bline.rb
+++ b/examples/bline.rb
@@ -3,7 +3,7 @@ require 'canis/core/util/rcommandwindow'
 require 'fileutils'
 require 'pathname'
 require 'canis/core/include/defaultfilerenderer'
-require './common/devel.rb'
+require_relative './common/devel.rb'
 
 # this will go into top namespace so will conflict with other apps!
 def testnumberedmenu
@@ -32,7 +32,7 @@ def testdisplay_text
 end
 def testdir
   # this behaves like vim's file selector, it fills in values
-  str = rb_gets("File?  ", Pathname)  do |q| 
+  str = rb_gets("File?  ", Pathname)  do |q|
     #q.completion_proc = Proc.new {|str| Dir.glob(str +"*").collect { |f| File.directory?(f) ? f+"/" : f  } }
     q.help_text = "Enter start of filename and tab to get completion"
   end
@@ -43,9 +43,9 @@ end
 # method_missing gave a stack overflow.
 def execute_this(meth, *args)
   alert " #{meth} not found ! "
-  $log.debug "app email got #{meth}  " if $log.debug? 
+  $log.debug "app email got #{meth}  " if $log.debug?
   cc = @form.get_current_field
-  [cc].each do |c|  
+  [cc].each do |c|
     if c.respond_to?(meth, true)
       c.send(meth, *args)
       return true
@@ -54,7 +54,7 @@ def execute_this(meth, *args)
   false
 end
 
-App.new do 
+App.new do
   @startdir ||= File.expand_path("..")
   def show file
     w = @form.by_name["tv"]
@@ -63,43 +63,43 @@ App.new do
       w.text lines
       w.title "[ #{file} ]"
     elsif File.exists? file
-      lines = File.open(file,'r').readlines 
+      lines = File.open(file,'r').readlines
       w.text lines
       w.title "[ #{file} ]"
     end
   end
   def testchoosedir
     # list filters as you type
-    $log.debug "called CHOOSE " if $log.debug? 
-    str = choose_file  :title => "Select a file", 
+    $log.debug "called CHOOSE " if $log.debug?
+    str = choose_file  :title => "Select a file",
       :recursive => true,
       :dirs => true,
       :directory => @startdir,
       :help_text => "Enter pattern, use UP DOWN to traverse, Backspace to delete, ENTER to select. Esc-Esc to quit"
     if str
-      message "We got #{str} " 
+      message "We got #{str} "
       show str
     end
   end
   def testchoosefile
     # list filters as you type a pattern
     glob = "**/*.rb"
-    str = choose_file  glob, :title => "Select a file", 
+    str = choose_file  glob, :title => "Select a file",
       :directory => @startdir,
       :help_text => "Enter pattern, use UP DOWN to traverse, Backspace to delete, ENTER to select. Esc-Esc to quit"
     if str and str != ""
-      message "We got #{str} " 
+      message "We got #{str} "
       show str
     end
   end
   ht = 24
   borderattrib = :reverse
-  @header = app_header "canis #{Canis::VERSION}", :text_center => "rCommandline Test", 
+  @header = app_header "canis #{Canis::VERSION}", :text_center => "rCommandline Test",
     :text_right =>"Press :", :color => :white, :bgcolor => 236
   message "Press F10 (or qq) to exit, F1 Help, : for Menu  "
 
 
-    
+
     # commands that can be mapped to or executed using M-x
     # however, commands of components aren't yet accessible.
     def get_commands
@@ -107,7 +107,7 @@ App.new do
     end
     def help_text
       <<-eos
-               rCommandLine HELP 
+               rCommandLine HELP
 
       These are some features for either getting filenames from user
       at the bottom of the window like vim and others do, or filtering
@@ -130,7 +130,7 @@ App.new do
       testdir          - vim style, tabbing completes matching files
       testnumberedmenu - use menu indexes to select options
       testdisplaylist  - display a list at bottom of screen
-                         Press <ENTER> to select, arrow keys to traverse, 
+                         Press <ENTER> to select, arrow keys to traverse,
                          and characters to filter list.
       testdisplaytext  - display text at bottom (current file contents)
                          Press <ENTER> when done.
@@ -164,10 +164,10 @@ App.new do
       menu.display_new :title => "Menu"
     end
   @form.bind_key(?:, "App Menu") { app_menu; }
-  @form.bind_key(?=, "Choose File") { 
+  @form.bind_key(?=, "Choose File") {
       @curdir ||= Dir.pwd
       Dir.chdir(@curdir) if Dir.pwd != @curdir
-    #testdisplay_list; 
+    #testdisplay_list;
     testchoosefile;
   }
 
@@ -175,7 +175,7 @@ App.new do
     tv = textview :height_pc => 100, :width_pc => 100, :name => "tv", :suppress_borders => true
     tv.renderer ruby_renderer
   end # stack
-    
+
   sl = status_line :row => Ncurses.LINES-1
-  testdisplay_list 
+  testdisplay_list
 end # app

--- a/examples/dbdemo.rb
+++ b/examples/dbdemo.rb
@@ -1,5 +1,9 @@
 require 'canis/core/util/app'
-require 'sqlite3'
+begin
+  require 'sqlite3'
+rescue LoadError
+  puts "LoadError: You need sqlite3 installed for this example"
+end
 
 def menu_bar hash, config={}, &block
   if hash.is_a? Hash
@@ -27,9 +31,9 @@ def menu_bar hash, config={}, &block
     width = config[:title].size + 4 if width < config[:title].size + 4
   end
   height = config[:height]
-  height ||= [max_visible_items || 10+2, list.length+2].min 
-  #layout(1+height, width+4, row, col) 
-  layout = { :height => 0+height, :width => 0+width, :top => row, :left => col } 
+  height ||= [max_visible_items || 10+2, list.length+2].min
+  #layout(1+height, width+4, row, col)
+  layout = { :height => 0+height, :width => 0+width, :top => row, :left => col }
   window = Canis::Window.new(layout)
   window.name = "WINDOW:popuplist"
   window.wbkgd(Ncurses.COLOR_PAIR($reversecolor));
@@ -44,17 +48,17 @@ def menu_bar hash, config={}, &block
   listconfig[:height] = height
   listconfig[:selection_mode] ||= :single
   listconfig.merge!(config)
-  listconfig.delete(:row); 
-  listconfig.delete(:col); 
+  listconfig.delete(:row);
+  listconfig.delete(:col);
   # trying to pass populists block to listbox
   lb = Canis::Listbox.new form, listconfig, &block
   #lb.should_show_focus = true
   #$row_focussed_attr = REVERSE
 
-  
-  # added next line so caller can configure listbox with 
+
+  # added next line so caller can configure listbox with
   # events such as ENTER_ROW, LEAVE_ROW or LIST_SELECTION_EVENT or PRESS
-  # 2011-11-11 
+  # 2011-11-11
   #yield lb if block_given? # No it won't work since this returns
   window.wrefresh
   Ncurses::Panel.update_panels
@@ -92,7 +96,7 @@ def menu_bar hash, config={}, &block
             if val.is_a? Hash or val.is_a? Array
               unentered_hash = val
               choices << lb.current_value
-              unentered_window, _list = display_submenu val, :row => lb.current_index, :col => lb.width, :relative_to => lb, 
+              unentered_window, _list = display_submenu val, :row => lb.current_index, :col => lb.width, :relative_to => lb,
                 :bgcolor => :cyan
             end
           else
@@ -106,7 +110,7 @@ def menu_bar hash, config={}, &block
             if val
               choices << lb.current_value
               unentered_hash = val
-              unentered_window, _list = display_submenu val, :row => lb.current_index, :col => lb.width, :relative_to => lb, 
+              unentered_window, _list = display_submenu val, :row => lb.current_index, :col => lb.width, :relative_to => lb,
                 :bgcolor => :cyan
             end
 
@@ -190,9 +194,9 @@ def display_submenu hash, config={}, &block
     width = config[:title].size + 4 if width < config[:title].size + 4
   end
   height = config[:height]
-  height ||= [max_visible_items || 10+2, list.length+2].min 
-  #layout(1+height, width+4, row, col) 
-  layout = { :height => 0+height, :width => 0+width, :top => row, :left => col } 
+  height ||= [max_visible_items || 10+2, list.length+2].min
+  #layout(1+height, width+4, row, col)
+  layout = { :height => 0+height, :width => 0+width, :top => row, :left => col }
   window = Canis::Window.new(layout)
   window.name = "WINDOW:popuplist"
   window.wbkgd(Ncurses.COLOR_PAIR($reversecolor));
@@ -205,15 +209,15 @@ def display_submenu hash, config={}, &block
   listconfig[:height] = height
   listconfig[:selection_mode] ||= :single
   listconfig.merge!(config)
-  listconfig.delete(:row); 
-  listconfig.delete(:col); 
+  listconfig.delete(:row);
+  listconfig.delete(:col);
   # trying to pass populists block to listbox
   lb = Canis::Listbox.new form, listconfig, &block
 
-  
-  # added next line so caller can configure listbox with 
+
+  # added next line so caller can configure listbox with
   # events such as ENTER_ROW, LEAVE_ROW or LIST_SELECTION_EVENT or PRESS
-  # 2011-11-11 
+  # 2011-11-11
   #yield lb if block_given? # No it won't work since this returns
   window.wrefresh
   Ncurses::Panel.update_panels
@@ -294,7 +298,7 @@ def create_menu
   # menu should have array of hashes (or just a string)
   #db = { :name => "Databases", :accelerator => "M-d", :enabled = true, :on_right => :get_databases }
   #or = { :name => "Open Recent", :accelerator => "M-o", :enabled = true, :on_right => :get_recent }
-  #find_array = {"Find ..." => :find, "Find Next" => :find_next, "Find Previous" => :find_prev} 
+  #find_array = {"Find ..." => :find, "Find Next" => :find_next, "Find Previous" => :find_prev}
   items["File    >"] = ["Open ...       C-o" , "Open Recent",  "Databases" , "Tables", "Exit"]
   items["Window  >"] = { "Tile" => nil, "Find   >" => {"Find ..." => :find, "Find Next" => :find_next, "Find Previous" => :find_prev},
    "Edit" => nil, "Whatever" => nil}
@@ -326,7 +330,7 @@ def create_menu
     ix = popuplist( items[value] , :row => r + 2 + ix, :col => 10, :bgcolor => :cyan, :color => :white)
   end
 end
-# 
+#
 # changed order of name and fields, thanks hramrach
 def view_data name, fields="*"
   fields = "*" if fields == ""
@@ -355,7 +359,7 @@ def view_sql stmt
     require 'canis/core/widgets/tabular'
     t = Tabular.new do |t|
       t.headings = $columns
-      t.data=content   
+      t.data=content
     end
     view t.render
   end
@@ -366,7 +370,7 @@ def view_sql stmt
   end
 end
 
-App.new do 
+App.new do
   $log = create_logger "canisdb.log"
   #header = app_header "canis #{Canis::VERSION}", :text_center => "Database Demo", :text_right =>"enabled"
   form = @form
@@ -384,7 +388,7 @@ App.new do
   end
   def help_text
     <<-eos
-               DBDEMO HELP 
+               DBDEMO HELP
 
       This is some help text for dbdemo.
       We are testing out this feature.
@@ -407,7 +411,7 @@ App.new do
       Alt-x    -   Command mode (<tab> to see commands and select)
       :        -   Command mode
       Alt-z    -   Commands in TextArea
-      
+
                 Sql Entry Area
       C-x e        Edit in $EDITOR or vi
       M-?          To see other key-bindings
@@ -442,13 +446,13 @@ App.new do
           @form.by_name["clist"].clear_selection
           @form.by_name["clist"].remove_all
         end
-        
+
       else
         alert "Can't find a .db or .sqlite file"
       end
   end
   @form.help_manager.help_text = help_text()
-  # TODO accelerators and 
+  # TODO accelerators and
   # getting a handle for later use
   mb = menubar do
     keep_visible true
@@ -456,7 +460,7 @@ App.new do
     menu "File" do
       item "Open", "O" do
         accelerator "Ctrl-O"
-        command do 
+        command do
           alert "HA!! you wanted to open a file?"
         end
       end
@@ -484,9 +488,9 @@ App.new do
           create_popup(get_column_names(text), :multiple) { |value| view_data( text, value.join(",") ) }
         end
       end
-      item "New", "N" 
+      item "New", "N"
       separator
-      item "Exit", "x"  do 
+      item "Exit", "x"  do
         accelerator "F10"
         command do
           throw(:close)
@@ -523,7 +527,7 @@ App.new do
     end
     menu "Shell" do
       require 'canis/core/include/appmethods.rb'
-      require './common/devel.rb'
+      require_relative './common/devel.rb'
       item "Shell Output ..." do
         command { shell_output }
       end
@@ -568,7 +572,7 @@ App.new do
         # too much confusion between selected and focussed row
         #$current_table = eve.text if $db
       #end
-      clist = listbox :name => "clist", :list => ["No columns"], :title => "Columns", :height => 14, 
+      clist = listbox :name => "clist", :list => ["No columns"], :title => "Columns", :height => 14,
         :selection_mode => :multiple,
         :selected_color => :cyan, :selected_bgcolor => :white , :selected_attr => Ncurses::A_REVERSE,
         :help_text => "Enter to View selected fields, 'v' to select columns, w - where, o-order"
@@ -576,11 +580,11 @@ App.new do
 
       # change selected color when user enters or exits
       [clist , tlist].each do |o|
-        o.bind(:ENTER) do 
+        o.bind(:ENTER) do
           # reduce flicker by only modifying if necesssary
           o.selected_color = :cyan if o.selected_color != :cyan
         end
-        o.bind(:LEAVE) do 
+        o.bind(:LEAVE) do
           # reduce flicker by only modifying if necesssary
           o.selected_color = :blue unless o.selected_indices.empty?
         end
@@ -602,7 +606,7 @@ App.new do
           end
           view_data $selected_table, cols
         else
-          alert "Select a table first ('v' selects)." 
+          alert "Select a table first ('v' selects)."
         end
       end
       clist.bind_key('w', 'add to where condition') {
@@ -629,41 +633,41 @@ App.new do
         $log.debug "XXX: ORDER: #{$order_columns}. Press F4 when done"
       }
       @statusline = status_line :row => -3, :bgcolor => :magenta, :color => :black
-      @statusline.command { 
+      @statusline.command {
         # trying this out. If you want a persistent message that remains till the next on
         #  then send it in as $status_message
         text = $status_message.value || ""
         if !$current_db
           "[%-s] %s" % [ "#[bg=red,fg=white,bold]Select a Database#[end]", text]
         elsif !$current_table
-          "[DB: #[fg=white,bg=blue]%-s#[end] | %-s ] %s" % [ $current_db || "None", $current_table || "#[bg=red,fg=white]Select a table#[end]", text] 
+          "[DB: #[fg=white,bg=blue]%-s#[end] | %-s ] %s" % [ $current_db || "None", $current_table || "#[bg=red,fg=white]Select a table#[end]", text]
         else
-          "DB: #[fg=white,bg=green,bold]%-s#[end] | #[fg=white,bold]%-s#[end] ] %s" % [ $current_db || "None", $current_table || "----", text] 
+          "DB: #[fg=white,bg=green,bold]%-s#[end] | #[fg=white,bold]%-s#[end] ] %s" % [ $current_db || "None", $current_table || "----", text]
         end
       }
       @adock = nil
       keyarray = [
-        ["F1" , "Help"], ["F10" , "Exit"], 
+        ["F1" , "Help"], ["F10" , "Exit"],
         ["F2", "Menu"], ["F4", "View"],
         ["M-d", "Database"], ["M-t", "Table"],
         ["M-x", "Command"], nil
       ]
       tlist_keyarray = keyarray + [ ["v", "Select"], nil, ["Enter","View"] ]
 
-      clist_keyarray = keyarray + [ ["v", "Select"], ["V", "Range Sel"], 
+      clist_keyarray = keyarray + [ ["v", "Select"], ["V", "Range Sel"],
         ["Enter","View"], ['w', 'where'],
         ["o","order by"], ['O', 'order desc']
       ]
       tarea_keyarray = keyarray + [ ["M-z", "Commands"], nil ]
-      #tarea_sub_keyarray = [ ["r", "Run"], ["c", "clear"], ["w","Save"], ["a", "Append next"], 
+      #tarea_sub_keyarray = [ ["r", "Run"], ["c", "clear"], ["w","Save"], ["a", "Append next"],
       #["y", "Yank"], ["Y", "yank pop"] ]
-      tarea_sub_keyarray = [ ["r", "Run"], ["c", "clear"], ["e", "Edit externally"], ["w","Kill Ring Save (M-w)"], ["a", "Append Next"], 
+      tarea_sub_keyarray = [ ["r", "Run"], ["c", "clear"], ["e", "Edit externally"], ["w","Kill Ring Save (M-w)"], ["a", "Append Next"],
         ["y", "Yank (C-y)"], ["Y", "yank pop (M-y)"],
         ["u", "Undo (C-_)"], ["R", "Redo (C-r)"],
       ]
 
       gw = get_color($reversecolor, 'green', 'black')
-      @adock = dock keyarray, { :row => Ncurses.LINES-2, :footer_color_pair => $datacolor, 
+      @adock = dock keyarray, { :row => Ncurses.LINES-2, :footer_color_pair => $datacolor,
         :footer_mnemonic_color_pair => gw }
       @adock.set_key_labels tlist_keyarray, :tables
       @adock.set_key_labels clist_keyarray, :columns
@@ -741,7 +745,7 @@ App.new do
           end
           view_data $current_table, cols
         else
-          alert "Select a table first." 
+          alert "Select a table first."
         end
       end
     end # stack
@@ -777,7 +781,7 @@ App.new do
       while((ch = @window.getchar()) != ?\C-c.getbyte(0) )
         if ch < 33 || ch > 126
           Ncurses.beep
-        elsif !keys.include?(ch.chr) 
+        elsif !keys.include?(ch.chr)
           Ncurses.beep
         else
           hash.fetch(ch.chr).call
@@ -795,7 +799,7 @@ App.new do
 
           if filename
             str = tarea.get_text
-            File.open(filename, 'a') {|f| f.write(str) } 
+            File.open(filename, 'a') {|f| f.write(str) }
             @oldfilename = filename
             @cmd_history << filename unless @cmd_history.include? filename
 
@@ -809,18 +813,18 @@ App.new do
           filter = "*"
           #str = choose filter, :title => "Files", :prompt => "Choose a file: "
           cproc = Proc.new { |str| Dir.glob(str + "*") }
-          str = rb_gets "Choose a file: ", :title => "Files", :tab_completion => cproc, 
+          str = rb_gets "Choose a file: ", :title => "Files", :tab_completion => cproc,
             :help_text => "Press <tab> to complete filenames. C-a, C-e, C-k. Alt-?"
           if str && File.exists?(str)
             begin
-              tarea.set_content(str) 
+              tarea.set_content(str)
               message "Read content from #{str} "
             rescue => err
               print_error_message "No file named: #{str}: #{err.to_s} "
             end
           end
         end
-        #ok_button = button( [button_row,30], "OK", {:mnemonic => 'O'}) do 
+        #ok_button = button( [button_row,30], "OK", {:mnemonic => 'O'}) do
         #end
       end
       blank

--- a/examples/dirtree.rb
+++ b/examples/dirtree.rb
@@ -1,9 +1,8 @@
 require 'canis/core/util/app'
 require 'fileutils'
 require 'canis/core/widgets/tree/treemodel'
-#require 'canis/common/file'
-require './common/file'
-require './common/devel'
+require_relative './common/file'
+require_relative './common/devel'
 
 def _directories wd
   $log.debug " directories got :#{wd}: "
@@ -16,7 +15,7 @@ def _directories wd
   return ent
 end
 $log = create_logger "canis14.log"
-App.new do 
+App.new do
   def help_text
     <<-eos
 
@@ -56,7 +55,7 @@ App.new do
       files.delete(".")
       #files = file_listing path, :mode => :LONG
       ll.clear_selection
-      ll.list files 
+      ll.list files
       ll.title path
       #TODO show all details in filelist
       @current_path = path
@@ -73,14 +72,14 @@ App.new do
   # we have an array of path, to add recursively, one below the other
   nodes = []
   nodes <<  TreeNode.new(patharray.shift)
-  patharray.each do |e| 
+  patharray.each do |e|
     nodes <<  nodes.last.add(e)
   end
   last = nodes.last
   nodes.last.add entries
   model = DefaultTreeModel.new nodes.first
   model.root_visible = false
-     
+
 
 
   ht = FFI::NCurses.LINES - 2
@@ -93,7 +92,7 @@ App.new do
       path = File.join(*node.user_object_path)
       dirs = _directories path
       ch = node.children
-      ch.each do |e| 
+      ch.each do |e|
         o = e.user_object
         if dirs.include? o
           dirs.delete o
@@ -117,7 +116,7 @@ App.new do
     end # select
     #$def_bg_color = :blue
     @form.bgcolor = :blue
-    @t.expand_node last # 
+    @t.expand_node last #
     @t.mark_parents_expanded last # make parents visible
     @l = listbox :width_pc => 70, :border_attrib => borderattrib, :selection_mode => :single, :name => 'll',
       :left_margin => 1
@@ -153,7 +152,7 @@ App.new do
         file_edit _f if File.exists? _f
       end
     end
-    @form.bind_key([?\\, ?l, ?1]){ 
+    @form.bind_key([?\\, ?l, ?1]){
       ll = @form.by_name["ll"]
       ll.renderer.formatter = proc do | fname, stat, prefix|
         "%s%-40s | %10d | %s " % [prefix, fname, stat.size, stat.mtime.strftime("%Y-%m-%d")]
@@ -164,7 +163,7 @@ App.new do
       ll.repaint
       #ll.fire_dimension_changed
     }
-    @form.bind_key([?\\, ?l, ?2]){ 
+    @form.bind_key([?\\, ?l, ?2]){
       ll = @form.by_name["ll"]
       ll.renderer.formatter = nil
       #ll.fire_dimension_changed

--- a/examples/newtabbedwindow.rb
+++ b/examples/newtabbedwindow.rb
@@ -15,9 +15,9 @@ class SetupTabbedPane
 
     r = Container.new nil, :suppress_borders => true
     l1 = Label.new nil, :name => "profile", :attr => 'bold', :text => "Profile"
-    f1 = LabeledField.new nil,  :name => "name", :maxlen => 20, :width => 20, :bgcolor => :white, 
+    f1 = LabeledField.new nil,  :name => "name", :maxlen => 20, :width => 20, :bgcolor => :white,
       :color => :black, :text => "abc", :label => ' Name: '
-    f2 = LabeledField.new nil, :name => "email", :width => 20, :bgcolor => :white, 
+    f2 = LabeledField.new nil, :name => "email", :width => 20, :bgcolor => :white,
       :color => :blue, :text => "me@google.com", :label => 'Email: '
     f3 = RadioButton.new nil, :variable => $config_hash, :text => "red", :value => "RED", :color => :red
     f4 = RadioButton.new nil, :variable => $config_hash, :text => "blue", :value => "BLUE", :color => :blue
@@ -46,14 +46,14 @@ class SetupTabbedPane
         item RadioButton.new nil, :row => 10, :col => 2, :text => "Underline", :value => "underline", :variable => $config_hash[:cursor]
       end
       tab "&Term" do
-        
+
         item Label.new nil, :text => "Arrow Key in Combos", :row => 2, :col => 2, :attr => 'bold'
         x = Variable.new
         $config_hash.set_value x, :term
         item RadioButton.new nil, :row => 3, :col => 2, :text => "ignore", :value => "ignore", :variable => $config_hash[:term]
         item RadioButton.new nil, :row => 4, :col => 2, :text => "popup", :value => "popup", :variable => $config_hash[:term]
         item RadioButton.new nil, :row => 5, :col => 2, :text => "next", :value => "next", :variable => $config_hash[:term]
-        cb = ComboBox.new nil, :row => 7, :col => 2, :width => 20, 
+        cb = ComboBox.new nil, :row => 7, :col => 2, :width => 20,
           :list => %w[xterm xterm-color xterm-256color screen vt100 vt102],
           :label => "Declare terminal as: "
         #radio.update_command() {|rb| ENV['TERM']=rb.value }
@@ -61,7 +61,7 @@ class SetupTabbedPane
         x.update_command do |rb|
           cb.arrow_key_policy=rb.value.to_sym
         end
-        
+
       end
       tab "Conta&iner" do
         item r

--- a/examples/newtesttabp.rb
+++ b/examples/newtesttabp.rb
@@ -24,8 +24,8 @@ class TestTabbedPane
       tp.add_tab "&Language" do
         _r = 2
         colors = [:red, :green, :cyan]
-        %w[ ruby jruby macruby].each_with_index { |e, i| 
-          item RadioButton.new nil, 
+        %w[ ruby jruby macruby].each_with_index { |e, i|
+          item RadioButton.new nil,
             :variable => $config_hash,
             :name => "radio1",
             :text => e,
@@ -40,7 +40,7 @@ class TestTabbedPane
         butts = [ "Use &HTTP/1.0", "Use &frames", "&Use SSL" ]
         bcodes = %w[ HTTP, FRAMES, SSL ]
         butts.each_with_index do |t, i|
-          item Canis::CheckBox.new nil, 
+          item Canis::CheckBox.new nil,
             :text => butts[i],
             :variable => $config_hash,
             :name => bcodes[i],

--- a/examples/tabular.rb
+++ b/examples/tabular.rb
@@ -2,7 +2,7 @@ require 'canis/core/util/app'
 require 'canis/core/widgets/listfooter'
 require 'canis/core/util/promptmenu'
 
-App.new do 
+App.new do
   # TODO: combine this with widget menu
   def app_menu
       menu = PromptMenu.new self do
@@ -20,7 +20,7 @@ App.new do
   # to execute when app_menu is invoked
   # very tricky , this depends on the keys that have been mapped
   # Here we are pushing the mapped key to trigger a method.
-  # FIXME NOTE these have stopped working since I think i now clear keys 
+  # FIXME NOTE these have stopped working since I think i now clear keys
   #  after a key is processed, so unget will not work.
   #  Use +handle_key+ instead of +ungetch+, although that won't work if multiple
   #   keys involved.
@@ -71,7 +71,7 @@ def help_text
     <a>         - select all
     <*>         - invert selection
 
-    </>         - <slash> for searching, 
+    </>         - <slash> for searching,
                   <n> to continue searching
 
     Keys specific to this example
@@ -81,7 +81,7 @@ def help_text
     <o>         - insert a row after current one
     <U>         - undo delete
 
-         Motion keys 
+         Motion keys
 
     Usual for [[list]] and [[textpad]] such as :
     j, k, h, l
@@ -120,8 +120,8 @@ def _edit h, row, title
   config = { :width => 70, :title => title }
   bw = get_color $datacolor, :black, :white
   mb = MessageBox.new config do
-    h.each_with_index { |f, i| 
-      add LabeledField.new :label => "%*s:" % [_w, f], :text => row[i].chomp, :name => i.to_s, 
+    h.each_with_index { |f, i|
+      add LabeledField.new :label => "%*s:" % [_w, f], :text => row[i].chomp, :name => i.to_s,
         :bgcolor => :cyan,
         :width => 50,
         :label_color_pair => bw
@@ -130,7 +130,7 @@ def _edit h, row, title
   end
   index = mb.run
   return nil if index != 0
-  h.each_with_index { |e, i| 
+  h.each_with_index { |e, i|
     f = mb.widget(i.to_s)
     row[i] = f.text
   }
@@ -177,15 +177,15 @@ lf.command_right(){ |comp|
   " [#{comp.size} tasks]"
 }
 =end
-  header = app_header "canis #{Canis::VERSION}", :text_center => "Table Demo", :text_right =>": menu", 
-      :color => :black, :bgcolor => :green #, :attr => :bold 
+  header = app_header "canis #{Canis::VERSION}", :text_center => "Table Demo", :text_right =>": menu",
+      :color => :black, :bgcolor => :green #, :attr => :bold
   message "Press F10 to exit, F1 for help, : for menu"
   @form.help_manager.help_text = help_text()
   $orig_cols = Ncurses.COLS
   $orig_rows = Ncurses.LINES
 
   h = %w[ Id Title Priority Status]
-  file = "data/table.txt"
+  file = File.expand_path("../data/table.txt", __FILE__)
 
   flow :margin_top => 1, :height => FFI::NCurses.LINES-2 do
     tw = table :print_footer => true, :name => "tab"
@@ -204,7 +204,7 @@ lf.command_right(){ |comp|
     tw.bind_key(?e, 'edit row') {  edit_row tw }
     tw.bind_key(?o, 'insert row') {  insert_row tw }
     tw.create_default_sorter
-  
+
   end # stack
   status_line :row => FFI::NCurses.LINES-1
   @form.bind_key(?:, 'menu') {  app_menu }

--- a/examples/tasks.rb
+++ b/examples/tasks.rb
@@ -2,7 +2,7 @@ require 'canis/core/util/app'
 require 'canis/core/include/defaultfilerenderer'
 #require 'canis/core/widgets/rlist'
 
-App.new do 
+App.new do
 def resize
   tab = @form.by_name["tasklist"]
   cols = Ncurses.COLS
@@ -18,13 +18,13 @@ end
 
   message "Press F10 or qq to quit "
 
-  file = "data/todo.txt"
+  file = File.expand_path("../data/todo.txt", __FILE__)
   alist = File.open(file,'r').read.split("\n") if File.exists? file
   #flow :margin_top => 1, :item_width => 50 , :height => FFI::NCurses.LINES-2 do
   #stack :margin_top => 1, :width => :expand, :height => FFI::NCurses.LINES-4 do
 
     #task = field :label => "    Task:", :width => 50, :maxlen => 80, :bgcolor => :cyan, :color => :black
-    #pri = field :label => "Priority:", :width => 1, :maxlen => 1, :type => :integer, 
+    #pri = field :label => "Priority:", :width => 1, :maxlen => 1, :type => :integer,
       #:valid_range => 1..9, :bgcolor => :cyan, :color => :black , :default => "5"
     #pri.overwrite_mode = true
     # u,se voerwrite mode for this TODO and catch exception
@@ -44,26 +44,26 @@ end
     lb = listbox :list => alist.sort, :title => "[ todos ]", :name => "tasklist", :row => 1, :height => Ncurses.LINES-4, :width => Ncurses.COLS-1
     lb.should_show_focus = false
     lb.renderer dr
-    lb.bind_key(?d, "Delete Row"){ 
+    lb.bind_key(?d, "Delete Row"){
       if confirm("Delete #{lb.current_value} ?")
-        lb.delete_at lb.current_index 
+        lb.delete_at lb.current_index
         $data_modified = true
         # TODO reposition cursor at 0. use list_data_changed ?
       end
     }
-    lb.bind_key(?e, "Edit Row"){ 
+    lb.bind_key(?e, "Edit Row"){
       if ((value = get_string("Edit Task:", :width => 80, :default => lb.current_value, :maxlen => 80, :width => 70)) != nil)
 
         lb[lb.current_index]=value
         $data_modified = true
       end
     }
-    lb.bind_key(?a, "Add Record"){ 
+    lb.bind_key(?a, "Add Record"){
 
       # ADD
     task = LabeledField.new :label => "    Task:", :width => 60, :maxlen => 80, :bgcolor => :cyan, :color => :black,
     :name => 'task'
-    pri = LabeledField.new :label => "Priority:", :width => 1, :maxlen => 1, :type => :integer, 
+    pri = LabeledField.new :label => "Priority:", :width => 1, :maxlen => 1, :type => :integer,
       :valid_range => 1..9, :bgcolor => :cyan, :color => :black , :default => "5", :name => 'pri'
     pri.overwrite_mode = true
     config = {}
@@ -77,10 +77,10 @@ end
     end
     index = tp.run
     if index == 0 # OK
-      # when does this memory get released ??? XXX 
-      _t = tp.form.by_name['pri'].text 
+      # when does this memory get released ??? XXX
+      _t = tp.form.by_name['pri'].text
       if _t != ""
-        val =  @default_prefix + tp.form.by_name['pri'].text + ". " + tp.form.by_name['task'].text 
+        val =  @default_prefix + tp.form.by_name['pri'].text + ". " + tp.form.by_name['task'].text
         w = @form.by_name["tasklist"]
         _l = w.list
         _l << val
@@ -92,11 +92,11 @@ end
     end
     }
     # decrease priority
-    lb.bind_key(?-, 'decrease priority'){ 
+    lb.bind_key(?-, 'decrease priority'){
       line = lb.current_value
       p = line[1,1].to_i
       if p < 9
-        p += 1 
+        p += 1
         line[1,1] = p.to_s
         lb[lb.current_index]=line
         lb.list(lb.list.sort)
@@ -104,11 +104,11 @@ end
       end
     }
     # increase priority
-    lb.bind_key(?+, 'increase priority'){ 
+    lb.bind_key(?+, 'increase priority'){
       line = lb.current_value
       p = line[1,1].to_i
       if p > 1
-        p -= 1 
+        p -= 1
         line[1,1] = p.to_s
         lb[lb.current_index]=line
         lb.list(lb.list.sort)
@@ -120,7 +120,7 @@ end
       end
     }
     # mark as done
-    lb.bind_key(?x, 'mark done'){ 
+    lb.bind_key(?x, 'mark done'){
       line = lb.current_value
       line[0,1] = "x"
       lb[lb.current_index]=line
@@ -128,7 +128,7 @@ end
       $data_modified = true
     }
     # flag task with a single character
-    lb.bind_key(?!, 'flag'){ 
+    lb.bind_key(?!, 'flag'){
       line = lb.current_value.chomp
       value = get_string("Flag for #{line}. Enter one character.", :maxlen => 1, :width => 1)
       #if ((value = get_string("Edit Task:", :width => 80, :default => lb.current_value)) != nil)
@@ -146,7 +146,7 @@ end
   @form.bind(:RESIZE) {  resize }
 
     keyarray = [
-      ["F1" , "Help"], ["F10" , "Exit"], 
+      ["F1" , "Help"], ["F10" , "Exit"],
       ["F2", "Menu"], ["F4", "View"],
       ["d", "delete item"], ["e", "edit item"],
       ["a", "add item"], ["x", "close item"],
@@ -156,7 +156,7 @@ end
     ]
 
     gw = get_color($reversecolor, 'green', 'black')
-    @adock = dock keyarray, { :row => Ncurses.LINES-2, :footer_color_pair => $datacolor, 
+    @adock = dock keyarray, { :row => Ncurses.LINES-2, :footer_color_pair => $datacolor,
       :footer_mnemonic_color_pair => gw }
 
   @window.confirm_close_command do
@@ -167,13 +167,13 @@ end
     w = @form.by_name["tasklist"]
     if confirm("Save tasks?", :default_button => 0)
       system("cp #{file} #{file}.bak")
-      File.open(file, 'w') {|f| 
-        w.list.each { |e|  
-          f.puts(e) 
-        } 
-      } 
+      File.open(file, 'w') {|f|
+        w.list.each { |e|
+          f.puts(e)
+        }
+      }
     end
     end # if modif
   end
-  
+
 end # app

--- a/examples/term2.rb
+++ b/examples/term2.rb
@@ -12,8 +12,8 @@ require 'canis/core/widgets/scrollbar'
 
     The 2 tables on the right differ in behaviour. The first puts tabular data
     into a listbox so you get single/multiple selection. The second puts tabular
-    data into a textview, so there's no selection. <space> scrolls instead of 
-    selects <ENTER> allows us to use the word under cursor for further actions. 
+    data into a textview, so there's no selection. <space> scrolls instead of
+    selects <ENTER> allows us to use the word under cursor for further actions.
 
     To see an example of placing tabular data in a tabular widget, see tabular.rb.
     The advantage of tabular_widget is column resizing, hiding, aligning and sorting.
@@ -23,8 +23,8 @@ require 'canis/core/widgets/scrollbar'
 
     eos
   end
-App.new do 
-  header = app_header "canis #{Canis::VERSION}", :text_center => "Tabular Demo", :text_right =>"New Improved!", :color => :black, :bgcolor => :white, :attr => :bold 
+App.new do
+  header = app_header "canis #{Canis::VERSION}", :text_center => "Tabular Demo", :text_right =>"New Improved!", :color => :black, :bgcolor => :white, :attr => :bold
   message "F10 quit, F1 Help, ? Bindings"
   #install_help_text my_help_text
   @form.help_manager.help_text = my_help_text
@@ -45,8 +45,8 @@ App.new do
     end # stack
 
 
-    file = "data/tasks.csv"
-    lines = File.open(file,'r').readlines 
+    file = File.expand_path("../data/tasks.csv", __FILE__)
+    lines = File.open(file,'r').readlines
     heads = %w[ id sta type prio title ]
     t = Tabular.new do |t|
       t.headings = heads
@@ -63,9 +63,9 @@ App.new do
       res = r.split("\n")
 
       t = Tabular.new do
-        #      self.headings = 'Perm', 'Gr', 'User', 'U',  'Size', 'Mon', 'Date', 'Time', 'File' # changed 2011 dts  
+        #      self.headings = 'Perm', 'Gr', 'User', 'U',  'Size', 'Mon', 'Date', 'Time', 'File' # changed 2011 dts
         self.headings = 'User',  'Size', 'Mon', 'Date', 'Time', 'File'
-        res.each { |e| 
+        res.each { |e|
           cols = e.split
           next if cols.count < 6
           cols = cols[3..-1]

--- a/examples/testbuttons.rb
+++ b/examples/testbuttons.rb
@@ -13,20 +13,20 @@ require 'canis'
 require 'canis/core/include/appmethods.rb'
 def help_text
       <<-eos
-               BUTTONS  HELP 
+               BUTTONS  HELP
 
       This is some help text for testbuttons.
       To select any button press the SPACEBAR, although ENTER will also work.
       You may also press the mnemonic or hotkey on the label..
 
-      The toggle button toggles the kind of dialog for the Cancel button. Modern look 
+      The toggle button toggles the kind of dialog for the Cancel button. Modern look
       and feel refers to a popup with buttons. This is like the links editor.
 
       Classic look and feel refers to a line at the bottom of the screen, with a y/n prompt.
       THis is like a lot of older apps, i think Pine and maybe vim.
 
 
-      Alt-c/F10 -   Exit application 
+      Alt-c/F10 -   Exit application
 
 
 
@@ -42,7 +42,7 @@ if $0 == __FILE__
   # Initialize curses
     Canis::start_ncurses  # this is initializing colors via ColorMap.setup
     path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
     $log = Logger.new(path)
     $log.level = Logger::DEBUG
 
@@ -50,8 +50,8 @@ if $0 == __FILE__
     @lookfeel = :dialog # or :classic
 
     @window = Canis::Window.root_window
-    # Initialize few color pairs 
-    # Create the window to be associated with the form 
+    # Initialize few color pairs
+    # Create the window to be associated with the form
     # Un post form and free the memory
 
     catch(:close) do
@@ -67,7 +67,7 @@ if $0 == __FILE__
 
       _mess = "Message Comes Here"
       message_label = Canis::Label.new @form, {text: _mess,
-        :name=>"message_label",:row => Ncurses.LINES-1, :col => 1, :width => 60,  
+        :name=>"message_label",:row => Ncurses.LINES-1, :col => 1, :width => 60,
         :height => 2, :color => :cyan}
 
       $results = Variable.new
@@ -108,7 +108,7 @@ if $0 == __FILE__
         mnemonic('T')
         #underline 0
       togglebutton.command do
-        if togglebutton.value 
+        if togglebutton.value
           message_label.text "Modern look and feel for dialogs"
         else
           message_label.text "Classic look and feel for dialogs"
@@ -119,20 +119,20 @@ if $0 == __FILE__
       @form.bind(:LEAVE) { |f|  f.label && f.label.bgcolor = 'black'   if f.respond_to? :label}
 
       row += 1
-      colorlabel = Label.new @form, {'text' => "Select a color:", "row" => row, "col" => col, 
+      colorlabel = Label.new @form, {'text' => "Select a color:", "row" => row, "col" => col,
         "color"=>"cyan", "mnemonic" => 'S'}
       #$radio = Variable.new
       #$radio.update_command(colorlabel) {|tv, label|  label.color tv.value; }
 #
-      #$radio.update_command() {|tv|  @form.widgets.each { |e| next unless e.is_a? Widget; 
+      #$radio.update_command() {|tv|  @form.widgets.each { |e| next unless e.is_a? Widget;
         #e.bgcolor tv.value };  }
 
       # whenever updated set colorlabel and messagelabel to bold
-      $results.update_command(colorlabel,checkbutton) {|tv, label, cb| 
+      $results.update_command(colorlabel,checkbutton) {|tv, label, cb|
         attrs =  cb.value ? 'bold' : 'normal'; label.attr(attrs); message_label.attr(attrs)}
 
 
-      checkbutton1.command do 
+      checkbutton1.command do
         attrs =  checkbutton1.value ? 'reverse' : 'normal'; colorlabel.attr(attrs); message_label.attr(attrs)
       end
       row += 1
@@ -178,17 +178,17 @@ if $0 == __FILE__
       end
       #$radio.update_command(colorlabel) {|tv, label|  label.color tv.value; }
 #
-      #$radio.update_command() {|tv|  @form.widgets.each { |e| next unless e.is_a? Widget; 
+      #$radio.update_command() {|tv|  @form.widgets.each { |e| next unless e.is_a? Widget;
         #e.bgcolor tv.value };  }
       colorlabel.label_for radio1
 
       group = ButtonGroup.new
-      [radio1, radio2, radio11, radio22].each { |r| 
+      [radio1, radio2, radio11, radio22].each { |r|
         group.add r
       }
       group.command(colorlabel) {|tv, label|  label.color tv.value; }
 #
-      group.command() {|tv|  @form.widgets.each { |e| next unless e.is_a? Widget; 
+      group.command() {|tv|  @form.widgets.each { |e| next unless e.is_a? Widget;
         e.bgcolor tv.value };  }
 
       # instead of using frozen, I will use a PropertyVeto
@@ -202,7 +202,7 @@ if $0 == __FILE__
             raise PropertyVetoException.new("Cannot change this!", e)
         end
       }
-      [radio1, radio2, radio11, radio22].each { |r| 
+      [radio1, radio2, radio11, radio22].each { |r|
         r.bind(:PROPERTY_CHANGE) do |e| veto.call(e, r.text) end
       }
 
@@ -223,7 +223,7 @@ if $0 == __FILE__
         #highlight_foreground "blue"
         mnemonic 'O'
       end
-      ok_button.command() { |eve| 
+      ok_button.command() { |eve|
         alert("Hope you enjoyed this demo - Press the Cancel button to quit", {'title' => "Hello", :bgcolor => :blue , :color => :white})
       }
 
@@ -238,15 +238,15 @@ if $0 == __FILE__
         #highlight_background "white"
         #highlight_foreground "blue"
         #surround_chars ['{ ',' }']  ## change the surround chars
-      cancel_button.command { |aeve| 
+      cancel_button.command { |aeve|
         #if @lookfeel == :dialog
         if togglebutton.value == true
-          ret = confirm("Do your really want to quit?") 
+          ret = confirm("Do your really want to quit?")
         else
-          ret = rb_confirm("Do your really want to quit?") 
+          ret = rb_confirm("Do your really want to quit?")
         end
-        if ret 
-          throw(:close); 
+        if ret
+          throw(:close);
         else
           message_label.text = "Quit aborted"
         end
@@ -263,9 +263,9 @@ if $0 == __FILE__
         begin
           @form.handle_key(ch)
 
-        rescue FieldValidationException => fve 
+        rescue FieldValidationException => fve
           alert fve.to_s
-          
+
           f = @form.get_current_field
           # lets restore the value
           if f.respond_to? :restore_original_value

--- a/examples/testcombo.rb
+++ b/examples/testcombo.rb
@@ -4,7 +4,7 @@ require 'canis/core/widgets/rcombo'
 require 'canis/core/include/appmethods.rb'
 def help_text
       <<-eos
-# COMBO  HELP 
+# COMBO  HELP
 
 This is some help text for |Combos|
 
@@ -30,13 +30,13 @@ if $0 == __FILE__
   # Initialize curses
     Canis::start_ncurses  # this is initializing colors via ColorMap.setup
     path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
     $log = Logger.new(path)
     $log.level = Logger::DEBUG
 
     @window = Canis::Window.root_window
-    # Initialize few color pairs 
-    # Create the window to be associated with the form 
+    # Initialize few color pairs
+    # Create the window to be associated with the form
     # Un post form and free the memory
 
     catch(:close) do
@@ -49,7 +49,7 @@ if $0 == __FILE__
 
 
 
-        cb = ComboBox.new @form, :row => 7, :col => 2, :width => 20, 
+        cb = ComboBox.new @form, :row => 7, :col => 2, :width => 20,
           :list => %w[xterm xterm-color xterm-256color screen vt100 vt102],
           :arrow_key_policy => :popup,
           :label => "Declare terminal as: "

--- a/examples/testdb.rb
+++ b/examples/testdb.rb
@@ -48,9 +48,9 @@ def _edit h, row, title
   bw = get_color $datacolor, :black, :white
   mb = MessageBox.new config do
     txt = nil
-    h.each_with_index { |f, i| 
+    h.each_with_index { |f, i|
       txt = row[i] || ""
-      add LabeledField.new :label => "%*s:" % [_w, f], :text => txt.chomp, :name => i.to_s, 
+      add LabeledField.new :label => "%*s:" % [_w, f], :text => txt.chomp, :name => i.to_s,
         :bgcolor => :cyan,
         :width => 50,
         :label_color_pair => bw
@@ -59,7 +59,7 @@ def _edit h, row, title
   end
   index = mb.run
   return nil if index != 0
-  h.each_with_index { |e, i| 
+  h.each_with_index { |e, i|
     f = mb.widget(i.to_s)
     row[i] = f.text
   }
@@ -69,7 +69,7 @@ begin
   # Initialize curses
   Canis::start_ncurses  # this is initializing colors via ColorMap.setup
   path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-  logfilename   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+  logfilename   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
   $log = Logger.new(logfilename)
   $log.level = Logger::DEBUG
 
@@ -84,7 +84,7 @@ begin
     @window = Canis::Window.root_window
     @form = Form.new @window
 
-    #header = app_header "0.0.1", :text_center => "Movie Database", :text_right =>"" , :name => "header" , :color => :white, :bgcolor => lineback , :attr => :bold 
+    #header = app_header "0.0.1", :text_center => "Movie Database", :text_right =>"" , :name => "header" , :color => :white, :bgcolor => lineback , :attr => :bold
 
 
 
@@ -146,7 +146,7 @@ begin
     tv.bind_key(?i) { insert_row(tv) }
     tv.bind_key(?D) { tv.delete_at tv.current_index }
     @form.bind_key(?\M-c, "Filter") {
-      tv = @form.by_name["tv"]; 
+      tv = @form.by_name["tv"];
       str = get_string "Enter name of director:"
       if str && str.length > 0
       m = tv.matching_indices do |ix, fields|

--- a/examples/testfields.rb
+++ b/examples/testfields.rb
@@ -3,7 +3,7 @@ require 'canis'
 require 'canis/core/include/appmethods.rb'
 def help_text
       <<-eos
-# FIELD  HELP 
+# FIELD  HELP
 
 This is some help text for |Fields|
 
@@ -16,8 +16,8 @@ Use Alt (meta) with the highlighted character to jump to that field.
 <Alt-m> goes to line, <Alt-p> to password.
 
 Notice how the field label (for first 3 fields) becomes red when focused (as in Pine/Alpine). This uses
-the event `:ENTER` and `:LEAVE` and +set_label+. The other fields use `LabeledField+. In the first 3, the 
-labels row and col have not been specified, so are calculated. In the last 3, label's lcol and lrow are 
+the event `:ENTER` and `:LEAVE` and +set_label+. The other fields use `LabeledField+. In the first 3, the
+labels row and col have not been specified, so are calculated. In the last 3, label's lcol and lrow are
 specified for custom placement.
 
 
@@ -49,15 +49,15 @@ if $0 == __FILE__
   # Initialize curses
     Canis::start_ncurses  # this is initializing colors via ColorMap.setup
     path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
     $log = Logger.new(path)
     $log.level = Logger::DEBUG
 
     @lookfeel = :classic # :dialog # or :classic
 
     @window = Canis::Window.root_window
-    # Initialize few color pairs 
-    # Create the window to be associated with the form 
+    # Initialize few color pairs
+    # Create the window to be associated with the form
     # Un post form and free the memory
 
     catch(:close) do
@@ -70,11 +70,11 @@ if $0 == __FILE__
       mnemonics = %w[ n l r p]
       %w[ name line regex password].each_with_index do |w,i|
         field = Field.new @form do
-          name w 
-          row  r 
-          col  fc 
+          name w
+          row  r
+          col  fc
           width  30
-          #text "abcd " 
+          #text "abcd "
           set_label Label.new @form, {:text => w, :color=> :cyan, :mnemonic => mnemonics[i]}
         end
         r += 1
@@ -87,7 +87,7 @@ if $0 == __FILE__
 
       @form.by_name["name"].text( "Not focusable").
         focusable(false)
-      
+
       @form.by_name["regex"].valid_regex(/^[A-Z][a-z]*/).
         text( "SYNOP").
         width(10).
@@ -102,10 +102,10 @@ if $0 == __FILE__
     r += 3
     l1 = Label.new @form, :name => "LabeledField", :attr => 'bold', :text => "Profile", :row => r, :col => fc
     r += 1
-    f1 = LabeledField.new @form,  :name => "name1", :maxlen => 20, :width => 20, :bgcolor => :white, 
+    f1 = LabeledField.new @form,  :name => "name1", :maxlen => 20, :width => 20, :bgcolor => :white,
       :color => :black, :text => "abc", :label => '    Name: ', :row => r, :col => fc
     r += 1
-    f2 = LabeledField.new @form, :name => "email", :width => 20, :bgcolor => :white, 
+    f2 = LabeledField.new @form, :name => "email", :width => 20, :bgcolor => :white,
       :color => :blue, :text => "me@google.com", :label => '   Email: ', :row => r, :col => fc
     r += 3
     f3 = LabeledField.new @form
@@ -129,7 +129,7 @@ if $0 == __FILE__
           bgcolor(:white).color(:black).
           row(r+i).col(fc).lcol(01)
       end
-      @form.bind_key(FFI::NCurses::KEY_F3,'view log') { 
+      @form.bind_key(FFI::NCurses::KEY_F3,'view log') {
         require 'canis/core/util/viewer'
         Canis::Viewer.view(path || "canis14.log", :close_key => KEY_ENTER, :title => "<Enter> to close")
       }
@@ -162,10 +162,10 @@ if $0 == __FILE__
         begin
           @form.handle_key(ch)
 
-        rescue FieldValidationException => fve 
+        rescue FieldValidationException => fve
           #alert fve.to_s
           textdialog fve
-          
+
           f = @form.get_current_field
           # lets restore the value
           if f.respond_to? :restore_original_value

--- a/examples/testflowlayout.rb
+++ b/examples/testflowlayout.rb
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------- #
 #         File: testflowlayout.rb
-#  Description: 
+#  Description:
 #       Author: j kepler  http://github.com/mare-imbrium/canis/
 #         Date: 2014-05-09 - 20:24
 #      License: MIT
@@ -21,7 +21,7 @@ if __FILE__ == $PROGRAM_NAME
     lb2 = Listbox.new @form, :list => `gem list --local`.split("\n") , :name => "mylist2"
 =begin
 
-    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails] 
+    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails]
     str = "Hello, people of Earth.\nI am HAL, a textbox.\nUse arrow keys, j/k/h/l/gg/G/C-a/C-e/C-n/C-p\n"
     str << alist.join("\n")
     tv = TextPad.new @form, :name => "text", :text => str.split("\n")
@@ -40,4 +40,4 @@ if __FILE__ == $PROGRAM_NAME
 
     st = status_line :row => -1
   end # app
-end # if 
+end # if

--- a/examples/testkeypress.rb
+++ b/examples/testkeypress.rb
@@ -1,5 +1,5 @@
 # demo to test keypresses
-# press any key and see the value that ncurses or our routines catch. 
+# press any key and see the value that ncurses or our routines catch.
 # Press alt and control combinations and Function keys
 # Ideally each key should return only one value. Sometimes, some TERM setting
 # or terminal emulator may not give correct values or may give different values
@@ -37,7 +37,7 @@ if $0 == __FILE__
       # please use a hash to pass these values, avoid this old style
       # i want to move away from it as it comlpicates code
         texta = TextPad.new @form do
-          name   "mytext" 
+          name   "mytext"
           row  r
           col  c
           width w
@@ -49,7 +49,7 @@ if $0 == __FILE__
           title_attrib (Ncurses::A_BOLD)
         end
       help = "q to quit. escdelay is #{nd}. Check keys. F1..10, C-a..z, Alt a-zA-Z0-9, C-left,rt, Sh-F5..10 .: #{$0}"
-      help1 = "Press in quick succession: 1) M-[, w     and (2)  M-[, M-w.        (3)  M-Sh-O, w."  
+      help1 = "Press in quick succession: 1) M-[, w     and (2)  M-[, M-w.        (3)  M-Sh-O, w."
       Canis::Label.new @form, {'text' => help, "row" => r+h+1, "col" => 2, "color" => "yellow"}
       Canis::Label.new @form, {'text' => help1, "row" => r+h+2, "col" => 2, "color" => "green"}
       texta.text = ["Press any key, Function, control, alt etc to see ","if it works.",

--- a/examples/testlistbox.rb
+++ b/examples/testlistbox.rb
@@ -1,20 +1,20 @@
 # NOTE: If the listbox is empty, that could mean that you have not generated
 #  ri documentation for this version of ruby. You can do so by doing:
-#    rvm docs generate-ri 
-#    or 
+#    rvm docs generate-ri
+#    or
 #    rvm docs generate
 #  (This assumes you are using rvm)
 #
-# WARNING : IF THIS PROGRAM HANGS check the ri command 
+# WARNING : IF THIS PROGRAM HANGS check the ri command
 # Maybe your version of ri has different options and is going interactive.
 # ruby 1.9.3's ri requires a -l option or else if becomes interactive.
 # this program tests out a listbox
-# This is written in the old style where we start and end ncurses and initiate a 
+# This is written in the old style where we start and end ncurses and initiate a
 # getch loop. It gives more control.
 # The new style is to use App which does the ncurses setup and teardown, as well
 # as manages keys. It also takes care of logger and includes major stuff.
 # NOTE : this is the new listbox (based on Textpad version, the original
-#  version has been moved to deprecated. 2014-04-08 - 18:32 
+#  version has been moved to deprecated. 2014-04-08 - 18:32
 require 'logger'
 require 'canis'
 require 'canis/core/widgets/listbox'
@@ -39,14 +39,14 @@ end
 Press <ENTER> on a class name on the first list, to view `ri` information
 for it on the right.
 
-Tab to right box, navigate to a method name, and press <ENTER> on a method 
+Tab to right box, navigate to a method name, and press <ENTER> on a method
 name, to see its details in a popup screen.
 Press */* <slash> in any box to search. e.g "/String" will take you to the
 first occurrence of "String". <n> will take you to the next match.
 
 To go quickly to the first Class starting with 'S', type <f> followed by <S>.
 Then press <n> to go to next match.
-    
+
 =========================================================================
 ## Vim Edit Keys
 
@@ -64,7 +64,7 @@ These are not of use here, but are demonstrative of list capabilities.
 ## Buffers
 
 Ordinary a [[textpad]] contains only one buffer. However, the one on the right
-is extended for multiple buffers. Pressing <ENTER> on the left on several 
+is extended for multiple buffers. Pressing <ENTER> on the left on several
 rows opens multiple buffers on the right. Use <M-n> (Alt-N) and <M-p> to navigate.
 ALternatively, <:> maps to a menu, so :n and :p may also be used.
 <BACKSPACE> will also go to previous buffer, like a browser.
@@ -81,15 +81,15 @@ if $0 == __FILE__
   # Initialize curses
     Canis::start_ncurses  # this is initializing colors via ColorMap.setup
     path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-    logfilename   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+    logfilename   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
     $log = Logger.new(logfilename)
     $log.level = Logger::DEBUG
 
     @window = Canis::Window.root_window
     $log.debug "  WINDOW #{FFI::NCurses.LINES} "
     $catch_alt_digits = true; # emacs like alt-1..9 numeric arguments
-    # Initialize few color pairs 
-    # Create the window to be associated with the form 
+    # Initialize few color pairs
+    # Create the window to be associated with the form
     # Un post form and free the memory
 
     catch(:close) do
@@ -103,14 +103,14 @@ if $0 == __FILE__
       r = 1; fc = 1;
 
       # this is the old style of using a label at the screen bottom, you can use the status_line
-      
+
       v = "F10 quits. F1 Help.  Try j k gg G o O C dd f<char> w yy p P / . Press ENTER on Class or Method"
-      var = Canis::Label.new @form, {'text' => v, "row" => FFI::NCurses.LINES-2, 
+      var = Canis::Label.new @form, {'text' => v, "row" => FFI::NCurses.LINES-2,
         "col" => fc, "width" => 100}
 
       h = FFI::NCurses.LINES-3
       file = "./data/ports.txt"
-      #mylist = File.open(file,'r').readlines 
+      #mylist = File.open(file,'r').readlines
       mylist = `ri -l `.split("\n")
       w = 25
       #0.upto(100) { |v| mylist << "#{v} scrollable data" }
@@ -131,8 +131,8 @@ if $0 == __FILE__
       listb.vieditable_init_listbox
       include Io
       listb.bind_key(?r, 'get file'){ get_file("Get a file:") }
-      listb.bind(:PRESS) { 
-        w = @form.by_name["tv"]; 
+      listb.bind(:PRESS) {
+        w = @form.by_name["tv"];
         #lines = `ri -f bs #{listb.current_value}`.split("\n")
         #lines = `ri -f ansi #{listb.current_value} 2>&1`.gsub('[m','[0m').split("\n")
         lines = get_data listb.current_value
@@ -144,7 +144,7 @@ if $0 == __FILE__
 
       tv = Canis::TextPad.new @form, :row => r, :col => w+1, :height => h, :width => FFI::NCurses.COLS-w-1,
       :name => "tv", :title => "Press Enter on method"
-      tv.set_content ["Press Enter on list to view ri information in this area.", 
+      tv.set_content ["Press Enter on list to view ri information in this area.",
         "Press ENTER on method name to see details"]
       require 'canis/core/include/multibuffer'
       tv.extend(Canis::MultiBuffers)
@@ -157,7 +157,7 @@ if $0 == __FILE__
         w = ev.word_under_cursor.strip
         # check that user did not hit enter on empty area
         if w != ""
-          #_text = `ri -f bs #{tv.title}.#{w} 2>&1` 
+          #_text = `ri -f bs #{tv.title}.#{w} 2>&1`
           #_text = _text.split("\n")
           _text = get_data "#{tv.title}.#{w}"
           if _text && _text.size != 0

--- a/examples/testlistbox1.rb
+++ b/examples/testlistbox1.rb
@@ -2,7 +2,7 @@ require 'canis/core/util/app'
 require 'canis/core/include/appmethods'
 require 'canis/core/widgets/listbox'
 require 'canis/core/util/promptmenu'
-require './common/devel.rb'
+require_relative './common/devel.rb'
 
   def my_help_text
     <<-eos
@@ -11,17 +11,17 @@ require './common/devel.rb'
     **Basic Usage**
 
     This simple example shows 2 lists inside a "flow". Each takes 50 percent
-    of the screen's width. 
+    of the screen's width.
 
     If you have brew installed, you can refresh the list to show actual
     brew packages on your system, using ':r'. Then you can view info, edit,
     or see the man page for that program.
 
     In the second list, you can refresh the list with your gems using ":r".
-    Place cursor on any gem, and execute any of the ":" commands to see the 
+    Place cursor on any gem, and execute any of the ":" commands to see the
     output. "edit" shells out to your EDITOR.
 
-    You can try multiple selection using <v> and <V> for range 
+    You can try multiple selection using <v> and <V> for range
     select. Check the general help screen for more [[list]] commands. The selections
     are not mapped to any command.
 
@@ -34,7 +34,7 @@ require './common/devel.rb'
 
 
 # just a simple test to ensure that rbasiclistbox is running inside a container.
-App.new do 
+App.new do
   devel_bindings
   def disp_menu
     # ideally this shuld get action_manager and add_action so these are added to widgets actions
@@ -101,12 +101,12 @@ App.new do
     res = %x[ gem which #{name} ].split("\n")
     res = res[0]
     if File.exists? res
-      require './common/file.rb'
+      require_relative './common/file.rb'
       file_edit res
     end
   end
   #
-  # general purpose command to catch miscellaneous actions that can be 
+  # general purpose command to catch miscellaneous actions that can be
   # executed in the same way. Or even take complex command lines
   # such as what vim has.
   def execute_this *cmd
@@ -143,7 +143,7 @@ App.new do
   colors = Ncurses.COLORS
   back = :blue
   back = 234 if colors >= 256
-  header = app_header "canis #{Canis::VERSION}", :text_center => "Basic List Demo", :text_right =>"New Improved!", :color => :white, :bgcolor => back #, :attr => :bold 
+  header = app_header "canis #{Canis::VERSION}", :text_center => "Basic List Demo", :text_right =>"New Improved!", :color => :white, :bgcolor => back #, :attr => :bold
   message "Press F10 to escape from here"
   #install_help_text my_help_text
   @form.help_manager.help_text = my_help_text
@@ -163,14 +163,14 @@ App.new do
 
   # testing triple bindings, along with a fall-back with only two bindings.
   @form.bind_key([?\\, ?\\, ?h]){ ht = @form.current_widget.help_text || "No help for this widget"; alert ht }
-  @form.bind_key([?\\, ?\\, ?H]){ ht = @form.current_widget.help_text || "No help for this widget"; 
+  @form.bind_key([?\\, ?\\, ?H]){ ht = @form.current_widget.help_text || "No help for this widget";
                                   str = get_string("Enter help text:", :default => ht);
                                   @form.current_widget.help_text = str
                                   }
   @form.bind_key([?\\, ?\\]){ alert "Enter h for seeing helptext on this widget, H for setting it"; }
 
-  alist = File.open("data/brew.txt",'r').readlines
-  list2 = File.open("data/gemlist.txt",'r').readlines
+  alist = File.open(File.expand_path("../data/brew.txt", __FILE__),'r').readlines
+  list2 = File.open(File.expand_path("../data/gemlist.txt", __FILE__),'r').readlines
   lb = nil
 
   flow :margin_top => 1, :height => FFI::NCurses.LINES-2 do
@@ -178,22 +178,22 @@ App.new do
       :left_margin => 0, :width_pc => 50, :name => 'lb1', :selection_mode => :single
     lb.show_selector = false
     lb.help_text = "Brew packages on your system. Use vim keys to navigate, or : to run a command"
-    
+
     lb2 = listbox :list => list2, :justify => :left, :title => "[ gems ]", :suppress_borders => false,
       :left_margin => 0, :width_pc => 50, :name => 'lb2'
     end
-  
- 
+
+
   label({:text => "F1 Help, F10 Quit. : for menu. Press F4 and F5 to test popup, v to select", :row => Ncurses.LINES-1, :col => 0, :name => 'lab'})
 
   @form.bind(:RESIZE) { resize() }
-  @form.bind_key(FFI::NCurses::KEY_F4, "Popup") { row = lb.visual_index+lb.row; col=lb.col+lb.current_value.length+1;  
-                                         
+  @form.bind_key(FFI::NCurses::KEY_F4, "Popup") { row = lb.visual_index+lb.row; col=lb.col+lb.current_value.length+1;
+
                                          row = [row, FFI::NCurses.LINES - 8].min
                                          ret = popuplist(%w[ chopin berlioz strauss tchaiko matz beethoven], :row => row, :col => col, :title => "Names", :bgcolor => :blue, :color => :white) ; alert "got #{ret} "}
 
   @form.bind_key(FFI::NCurses::KEY_F5, "Popup") {  list = %x[ls].split("\n");ret = popuplist(list, :title => "Files"); alert "Got #{ret} #{list[ret]} " }
 
-  @form.bind_key(?:, "Menu") { disp_menu; 
+  @form.bind_key(?:, "Menu") { disp_menu;
   }
 end # app

--- a/examples/testmessagebox.rb
+++ b/examples/testmessagebox.rb
@@ -28,7 +28,7 @@ if $0 == __FILE__
       when 1
         require 'canis/core/widgets/listbox'
         nn = "mylist"
-        l = Listbox.new  nil, :row => 2, :col => 5, :list => %w[john tim lee wong kepler edward why chad andy], 
+        l = Listbox.new  nil, :row => 2, :col => 5, :list => %w[john tim lee wong kepler edward why chad andy],
           :selection_mode => :multiple, :height => 10, :width => 20 , :selected_color => :green, :selected_bgcolor => :white, :selected_indices => [2,6], :name => nn
        #default_values %w[ lee why ]
 
@@ -85,7 +85,7 @@ if $0 == __FILE__
         button_type :ok
       end
       field = mb.widget("user")
-      field.bind(:ENTER) do |f|   
+      field.bind(:ENTER) do |f|
         listconfig = {:bgcolor => :blue, :color => :white,
                       :relative_to => field, :col => field.col + 6, :width => field.width}
         users= %w[john tim lee wong kepler edward _why chad andy]
@@ -107,7 +107,7 @@ if $0 == __FILE__
         #listb.bind(:ENTER_ROW) { field.text listb.selected_item }
         # if you find that cursor goes into listbox while typing, then
         # i've put set_form_row in listbox list_data_changed
-        field.bind(:CHANGE) do |f|   
+        field.bind(:CHANGE) do |f|
           flist = Dir.glob("*"+f.getvalue+"*")
           #l.insert( 0, *flist) if flist
           listb.list flist
@@ -129,8 +129,8 @@ if $0 == __FILE__
         mb.run
         $log.debug "MBOX :1selected #{listb}"
         $log.debug "MBOX :selected #{listb.selected_value}"
-      end 
-      
+      end
+
     end
   rescue => ex
   ensure

--- a/examples/testprogress.rb
+++ b/examples/testprogress.rb
@@ -20,7 +20,7 @@ if $0 == __FILE__
   # Initialize curses
     Canis::start_ncurses  # this is initializing colors via ColorMap.setup
     path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
     $log = Logger.new(path)
     $log.level = Logger::DEBUG
 
@@ -34,16 +34,16 @@ if $0 == __FILE__
       Label.new @form, {:text => "Old style and modern style progress bars", :row => 12, :col => 10}
       r = 14; fc = 12;
 
-      pbar1 = Progress.new @form, {:width => 20, :row => r, :col => fc, 
+      pbar1 = Progress.new @form, {:width => 20, :row => r, :col => fc,
         :name => "pbar1", :style => :old}
         #:bgcolor => :white, :color => 'red', :name => "pbar1", :style => :old}
-      pbar = Progress.new @form, {:width => 20, :row => r+2, :col => fc, 
+      pbar = Progress.new @form, {:width => 20, :row => r+2, :col => fc,
         :bgcolor => :white, :color => :red, :name => "pbar"}
-      
+
       pbar.visible false
       pb =  @form.by_name["pbar"]
       pb.visible true
-      len = 1 
+      len = 1
       ct = (100) * 1.00
       pb.fraction(len/ct)
       pbar1.fraction(len/ct)
@@ -61,7 +61,7 @@ if $0 == __FILE__
       # this is so there's no wait for a key, i want demo to proceed without key press, but
       # respond if there is one
       Ncurses::nodelay(@window.get_window, bf = true)
-     
+
       # sleep seconds between refresh of progress
       slp = 0.1
       ##while((ch = @window.getchar()) != FFI::NCurses::KEY_F10 )

--- a/examples/testree.rb
+++ b/examples/testree.rb
@@ -8,11 +8,11 @@ class Tester
     acolor = $reversecolor
   end
   def run
-    @window = Canis::Window.root_window 
+    @window = Canis::Window.root_window
     @form = Form.new @window
 
     h = 20; w = 75; t = 3; l = 4
-   #$choice = 1 
+   #$choice = 1
     case $choice
     when 1
     root    =  TreeNode.new "ROOT"
@@ -29,7 +29,7 @@ class Tester
     leaf1 << "leaf11"
     leaf1 << "leaf12"
 
-    root.add "blocky", true do 
+    root.add "blocky", true do
       add "block2"
       add "block3" do
         add "block31"

--- a/examples/testsplitlayout.rb
+++ b/examples/testsplitlayout.rb
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------- #
-#         File: testsplitlayout.rb 
-#  Description: 
+#         File: testsplitlayout.rb
+#  Description:
 #       Author: j kepler  http://github.com/mare-imbrium/canis/
 #         Date: 2014-05-09 - 20:24
 #      License: MIT
@@ -19,7 +19,7 @@ if __FILE__ == $PROGRAM_NAME
     lb1 = Listbox.new @form, :list => ["bach","beethoven","mozart","gorecki", "chopin","wagner","grieg","holst"] , :name => "mylist1"
 
 
-    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails] 
+    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails]
     str = "Hello, people of Earth.\nI am HAL, a textbox.\nUse arrow keys, j/k/h/l/gg/G/C-a/C-e/C-n/C-p\n"
     str << alist.join("\n")
     tv = TextPad.new @form, :name => "text", :text => str.split("\n")
@@ -50,4 +50,4 @@ if __FILE__ == $PROGRAM_NAME
 
     st = status_line :row => -1
   end # app
-end # if 
+end # if

--- a/examples/testsplitlayout1.rb
+++ b/examples/testsplitlayout1.rb
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------- #
-#         File: testsplitlayout.rb 
-#  Description: 
+#         File: testsplitlayout.rb
+#  Description:
 #       Author: j kepler  http://github.com/mare-imbrium/canis/
 #         Date: 2014-05-09 - 20:24
 #      License: MIT
@@ -19,7 +19,7 @@ if __FILE__ == $PROGRAM_NAME
     lb1 = Listbox.new @form, :list => ["bach","beethoven","mozart","gorecki", "chopin","wagner","grieg","holst"] , :name => "mylist1"
 
 
-    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails] 
+    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails]
     str = "Hello, people of Earth.\nI am HAL, a textbox.\nUse arrow keys, j/k/h/l/gg/G/C-a/C-e/C-n/C-p\n"
     str << alist.join("\n")
     tv = TextPad.new @form, :name => "text", :text => str.split("\n")
@@ -46,4 +46,4 @@ if __FILE__ == $PROGRAM_NAME
 
     st = status_line :row => -1
   end # app
-end # if 
+end # if

--- a/examples/teststacklayout.rb
+++ b/examples/teststacklayout.rb
@@ -1,7 +1,7 @@
 # #!/usr/bin/env ruby -w
 # ----------------------------------------------------------------------------- #
 #         File: teststacklayout.rb
-#  Description: 
+#  Description:
 #       Author: j kepler  http://github.com/mare-imbrium/canis/
 #         Date: 2014-05-08 - 23:34
 #      License: MIT
@@ -15,7 +15,7 @@ if __FILE__ == $PROGRAM_NAME
   App.new do
 
 
-      @form.bind_key(FFI::NCurses::KEY_F3,'view log') { 
+      @form.bind_key(FFI::NCurses::KEY_F3,'view log') {
         require 'canis/core/util/viewer'
         Canis::Viewer.view("canis14.log", :close_key => KEY_ENTER, :title => "<Enter> to close")
       }
@@ -26,7 +26,7 @@ if __FILE__ == $PROGRAM_NAME
     lb2 = Listbox.new @form, :list => `gem list --local`.split("\n") , :name => "mylist2"
 =begin
 
-    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails] 
+    alist = %w[ ruby perl python java jruby macruby rubinius rails rack sinatra pylons django cakephp grails]
     str = "Hello, people of Earth.\nI am HAL, a textbox.\nUse arrow keys, j/k/h/l/gg/G/C-a/C-e/C-n/C-p\n"
     str << alist.join("\n")
     tv = TextPad.new @form, :name => "text", :text => str.split("\n")
@@ -45,4 +45,4 @@ if __FILE__ == $PROGRAM_NAME
 
     st = status_line :row => -1
   end # app
-end # if 
+end # if

--- a/examples/testwsshortcuts.rb
+++ b/examples/testwsshortcuts.rb
@@ -49,7 +49,7 @@ if $0 == __FILE__
     # XXX update with new color and kb
     Canis::start_ncurses  # this is initializing colors via ColorMap.setup
     path = File.join(ENV["LOGDIR"] || "./" ,"canis14.log")
-    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT) 
+    file   = File.open(path, File::WRONLY|File::TRUNC|File::CREAT)
     $log = Logger.new(path)
     $log.level = Logger::DEBUG
     catch(:close) do

--- a/examples/testwsshortcuts2.rb
+++ b/examples/testwsshortcuts2.rb
@@ -35,7 +35,7 @@ class SetupMessagebox
             field :label => "%15s" % ["Address: "], :width => 15, :attr => :reverse
             blank
             check :text => "Using version control", :value => true, :onvalue => "yes", :offvalue => "no" do |eve|
-              unless eve.item.value 
+              unless eve.item.value
                 alert "NO VC! We need to talk"
               end
             end
@@ -53,7 +53,7 @@ class SetupMessagebox
             radio :text => "Window", :value => "Win", :group => :os
             blank
           flow  :item_width => 15 do
-            button :text => "Install" do 
+            button :text => "Install" do
               # you can avoid this by giving the radio buttons your own Variable (see test2.rb)
               choice = @variables[:os].value
               case choice
@@ -72,7 +72,7 @@ class SetupMessagebox
         end
       end # flow
       #button :text => "Execute"
-      text = ["      #[reverse]Unix Philosophy #[end]  ", 
+      text = ["      #[reverse]Unix Philosophy #[end]  ",
         "#[fg=green, underline]Eric Raymond#[end] in his book, #[fg=green, underline]The Art of Unix Programming#[end] summarized the Unix philosophy.",
       "  ",
         "Rule of #[fg=yellow]Modularity#[end]: Write simple parts connected by clean interfaces.",
@@ -91,7 +91,7 @@ class SetupMessagebox
         #t.formatted_text(text, :tmux)
         t.text(text, :content_type => :tmux)
         t1 = textview :title => 'ansi formatted document'
-        text = File.open("data/color.2","r").readlines
+        text = File.open(File.expand_path("../data/color.2", __FILE__),"r").readlines
         #text = `ri -f bs String`.split("\n")
         #t1.formatted_text(text, :ansi)
         t1.text(text, :content_type => :ansi)


### PR DESCRIPTION
I'm looking to use this gem for a project; upon reading that the examples are really the only true documentation and finding that most of them don't actually work by installing the gem and running them, I went through and fixed the pathing so they would run and I could see how they look. (Large diff is from being a lazy pedant with auto removing whitespace). 

Some dull contributions but I figured you might want them from my fork anyway. Neat project.
